### PR TITLE
Change OutOfBounds strategy for translation

### DIFF
--- a/src/main/resources/scripts/Plugins/Registration/Correct_3D_drift.py
+++ b/src/main/resources/scripts/Plugins/Registration/Correct_3D_drift.py
@@ -68,7 +68,7 @@ def translate_single_stack_using_imglib2(imp, dx, dy, dz):
   #   conversion into float is necessary due to "overflow of n-linear interpolation due to accuracy limits of unsigned bytes"
   #   see: https://github.com/fiji/fiji/issues/136#issuecomment-173831951
   img = ImagePlusImgs.from(imp.duplicate())
-  extended = Views.extendBorder(img)
+  extended = Views.extendZero(img)
   converted = Converters.convert(extended, RealFloatSamplerConverter())
   interpolant = Views.interpolate(converted, NLinearInterpolatorFactory())
   


### PR DESCRIPTION
`Views.extendZero` is less confusing for users if there's a large drift.

See [this discussion on the forum](http://forum.imagej.net/t/correct-3d-drift-artifact/5175?u=imagejan).